### PR TITLE
Fixed stored procedure to support array parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,5 +74,11 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.10</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.6</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/azure/cosmos/examples/common/CustomPOJO.java
+++ b/src/main/java/com/azure/cosmos/examples/common/CustomPOJO.java
@@ -5,9 +5,15 @@ package com.azure.cosmos.examples.common;
 
 public class CustomPOJO {
     private String id;
+    private String city;
 
     public CustomPOJO() {
 
+    }
+
+    public CustomPOJO(String id, String city) {
+        this.id = id;
+        this.city = city;
     }
 
     public CustomPOJO(String id) {
@@ -21,4 +27,8 @@ public class CustomPOJO {
     public void setId(String id) {
         this.id = id;
     }
+
+    public String getCity() { return city; }
+
+    public void setCity(String city) { this.city = city; }
 }


### PR DESCRIPTION
Reference: https://github.com/Azure-Samples/azure-cosmos-java-sql-api-samples/issues/16

The current code base doesn't support passing array parameters and transactions. With this PR the stored proc can support creates and updates although the java code base currently supports creates only.