### PR TITLE
Updated azure-cosmos dependency version to 4.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-cosmos</artifactId>
-            <version>4.6.0</version>
+            <version>4.7.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -2,10 +2,10 @@
 # Set root logger level to WARN and its appender to STDOUT.
 filter.threshold.type = ThresholdFilter
 filter.threshold.level = DEBUG
-rootLogger.level=INFO
+rootLogger.level=WARN
 rootLogger.appenderRef.stdout.ref=STDOUT
 logger.netty.name=io.netty
-logger.netty.level=INFO
+logger.netty.level=OFF
 logger.cosmos.name=com.azure.cosmos
 logger.cosmos.level=INFO
 # STDOUT is a ConsoleAppender and uses PatternLayout.


### PR DESCRIPTION
* Updated azure-cosmos dependency version to 4.7.1
* Updated logger to WARN level, turning off Netty INFO logs