### PR TITLE
Added publishOn operator and updated comments

### DIFF
--- a/src/main/java/com/azure/cosmos/examples/documentationsnippets/async/SampleDocumentationSnippetsAsync.java
+++ b/src/main/java/com/azure/cosmos/examples/documentationsnippets/async/SampleDocumentationSnippetsAsync.java
@@ -235,7 +235,7 @@ public class SampleDocumentationSnippetsAsync {
      */
 
     /** Performance tips - add scheduler */
-    public static void PerformanceTipsJavaSDKv4AddSchedulerSync() {
+    public static void PerformanceTipsJavaSDKv4AddSchedulerAsync() {
 
         CosmosAsyncContainer asyncContainer = null;
         CustomPOJO item = null;
@@ -244,13 +244,11 @@ public class SampleDocumentationSnippetsAsync {
 
         Mono<CosmosItemResponse<CustomPOJO>> createItemPub = asyncContainer.createItem(item);
         createItemPub
-                .subscribeOn(Schedulers.elastic())
+                .publishOn(Schedulers.parallel())
                 .subscribe(
                         itemResponse -> {
-                            //this is executed on eventloop IO netty thread.
-                            //the eventloop thread is shared and is meant to return back quickly.
-                            //
-                            // DON'T do this on eventloop IO netty thread.
+                            //this is now executed on reactor scheduler's parallel thread.
+                            //reactor scheduler's parallel thread is meant for CPU intensive work.
                             veryCpuIntensiveWork();
                         });
 


### PR DESCRIPTION
Based on testing, subscribeOn() won't help here, because internally SDK changes the threads to I/O, which then finally exposes the I/O thread back to the user. 
It is better to call publishOn() which will make sure whatever SDK does, it will always expose Reactor scheduler's thread to the end user, making it safe to not expose I/O threads. 