### PR TITLE
chore: set different estimated lag start position

### DIFF
--- a/src/main/java/com/azure/cosmos/examples/changefeed/SampleChangeFeedEstimator.java
+++ b/src/main/java/com/azure/cosmos/examples/changefeed/SampleChangeFeedEstimator.java
@@ -112,9 +112,9 @@ public class SampleChangeFeedEstimator {
                     logger.error("This never needs to be called, as this is just monitoring the state");
                 })
                 .buildChangeFeedProcessor();
-
-            AtomicInteger totalLag = new AtomicInteger();
             // <EstimatedLag>
+            AtomicInteger totalLag = new AtomicInteger();
+            
             Mono<List<ChangeFeedProcessorState>> currentState = changeFeedProcessorMainInstance.getCurrentState();
             currentState.map(state -> {
                 for (ChangeFeedProcessorState changeFeedProcessorState : state) {


### PR DESCRIPTION
Set different estimated lag start position, as other wise, the code sample here: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-use-change-feed-estimator?tabs=java#implement-the-change-feed-estimator does not make a lot of sense, as it is unclear what totalLag should be.