### PR TITLE
Bulk sample updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,11 @@
             <artifactId>azure-cosmos</artifactId>
             <version>LATEST</version>
         </dependency>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-identity</artifactId>
+            <version>1.15.4</version>
+        </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>

--- a/src/main/java/com/azure/cosmos/examples/bulk/async/BulkWriter.java
+++ b/src/main/java/com/azure/cosmos/examples/bulk/async/BulkWriter.java
@@ -111,6 +111,19 @@ public class BulkWriter {
                 "The operation for Item ID: [{}]  Item PartitionKey Value: [{}] will be retried",
                 itemOperation.getId(),
                 itemOperation.getPartitionKeyValue());
+            if (itemResponse.getRetryAfterDuration() != null) {
+                logger.info(
+                    "Retrying after [{}] milliseconds",
+                    itemResponse.getRetryAfterDuration().toMillis());
+                try {
+                    Thread.sleep(itemResponse.getRetryAfterDuration().toMillis());
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            } else {
+                logger.info("Retrying without delay");
+            }
+
             //re-scheduling
             scheduleWrites(itemOperation);
         } else {

--- a/src/main/java/com/azure/cosmos/examples/bulk/async/SampleBulkHandleRetriesAsync.java
+++ b/src/main/java/com/azure/cosmos/examples/bulk/async/SampleBulkHandleRetriesAsync.java
@@ -1,0 +1,204 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.examples.bulk.async;
+
+import com.azure.cosmos.ConsistencyLevel;
+import com.azure.cosmos.CosmosAsyncClient;
+import com.azure.cosmos.CosmosAsyncContainer;
+import com.azure.cosmos.CosmosAsyncDatabase;
+import com.azure.cosmos.CosmosClientBuilder;
+import com.azure.cosmos.GlobalThroughputControlConfig;
+import com.azure.cosmos.ThrottlingRetryOptions;
+import com.azure.cosmos.ThroughputControlGroupConfig;
+import com.azure.cosmos.ThroughputControlGroupConfigBuilder;
+import com.azure.cosmos.examples.common.AccountSettings;
+import com.azure.cosmos.examples.common.Families;
+import com.azure.cosmos.examples.common.Family;
+import com.azure.cosmos.models.CosmosBulkExecutionOptions;
+import com.azure.cosmos.models.CosmosBulkItemResponse;
+import com.azure.cosmos.models.CosmosBulkOperations;
+import com.azure.cosmos.models.CosmosContainerProperties;
+import com.azure.cosmos.models.CosmosContainerRequestOptions;
+import com.azure.cosmos.models.CosmosContainerResponse;
+import com.azure.cosmos.models.CosmosDatabaseResponse;
+import com.azure.cosmos.models.CosmosItemOperation;
+import com.azure.cosmos.models.CosmosItemRequestOptions;
+import com.azure.cosmos.models.CosmosPatchOperations;
+import com.azure.cosmos.models.PartitionKey;
+import com.azure.cosmos.models.ThroughputProperties;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class SampleBulkHandleRetriesAsync {
+
+    private static final Logger logger = LoggerFactory.getLogger(SampleBulkHandleRetriesAsync.class);
+    private final String databaseName = "AzureSampleFamilyDB";
+    private final String containerName = "FamilyContainer";
+    private CosmosAsyncClient client;
+    private CosmosAsyncDatabase database;
+    private CosmosAsyncContainer container;
+    private int noOfItemsToCreate = 500;
+
+    public static void main(String[] args) {
+        SampleBulkHandleRetriesAsync p = new SampleBulkHandleRetriesAsync();
+
+        try {
+            logger.info("Starting ASYNC main");
+            p.getStartedDemo();
+            logger.info("Demo complete, please hold while resources are released");
+        } catch (Exception e) {
+            e.printStackTrace();
+            logger.error(String.format("Cosmos getStarted failed with %s", e));
+        } finally {
+            logger.info("Closing the client");
+            p.shutdown();
+        }
+    }
+
+    public void close() {
+        client.close();
+    }
+
+    private void getStartedDemo() {
+
+        logger.info("Using Azure Cosmos DB endpoint: " + AccountSettings.HOST);
+
+        /* Create an async client
+        force rate limiting by reducing the max retry attempts
+        to simulate throttling when under heavy load*/
+        client = new CosmosClientBuilder()
+            .endpoint(AccountSettings.HOST)
+            .credential(new DefaultAzureCredentialBuilder().build())
+                .throttlingRetryOptions(
+                    new ThrottlingRetryOptions()
+                        .setMaxRetryAttemptsOnThrottledRequests(1)
+                        .setMaxRetryWaitTime(Duration.ofSeconds(1)))
+            .contentResponseOnWriteEnabled(true)
+            .consistencyLevel(ConsistencyLevel.SESSION).buildAsyncClient();
+
+ 
+        createDatabaseIfNotExists();
+        createContainerIfNotExists();
+
+        // Create 500 Family records
+        ArrayList<Family> largeFamilies1 = new ArrayList<>();
+        for (int i = 0; i < noOfItemsToCreate; i++) {
+            Family family = new Family();
+            family.setId(UUID.randomUUID().toString());
+            family.setLastName("Family0");
+            family.setRegistered(false);
+            largeFamilies1.add(family);
+        }
+        logger.info("Ensure rate limiting with enough bulk upserts, retries handled by BulkWriter abstraction");
+        largeBulkUpsertItemsWithBulkWriterAbstraction(largeFamilies1);
+    }
+
+    private void createDatabaseIfNotExists() {
+        logger.info("Create database " + databaseName + " if not exists.");
+
+        //  Create database if not exists
+        //  <CreateDatabaseIfNotExists>
+        Mono<CosmosDatabaseResponse> databaseIfNotExists = client.createDatabaseIfNotExists(databaseName);
+        databaseIfNotExists.flatMap(databaseResponse -> {
+            database = client.getDatabase(databaseResponse.getProperties().getId());
+            logger.info("Checking database " + database.getId() + " completed!\n");
+            return Mono.empty();
+        }).block();
+        //  </CreateDatabaseIfNotExists>
+    }
+
+    private void createContainerIfNotExists() {
+        logger.info("Create container " + containerName + " if not exists.");
+
+        //  Create container if not exists
+        //  <CreateContainerIfNotExists>
+
+        CosmosContainerProperties containerProperties = new CosmosContainerProperties(
+            containerName, "/lastName");
+        ThroughputProperties throughputProperties = ThroughputProperties.createManualThroughput(400);
+        Mono<CosmosContainerResponse> containerIfNotExists = database
+            .createContainerIfNotExists(containerProperties, throughputProperties);
+
+        //  Create container with 400 RU/s
+        CosmosContainerResponse cosmosContainerResponse = containerIfNotExists.block();
+        assert(cosmosContainerResponse != null);
+        assert(cosmosContainerResponse.getProperties() != null);
+        container = database.getContainer(cosmosContainerResponse.getProperties().getId());
+        //  </CreateContainerIfNotExists>
+
+        //Modify existing container
+        containerProperties = cosmosContainerResponse.getProperties();
+        Mono<CosmosContainerResponse> propertiesReplace =
+            container.replace(containerProperties, new CosmosContainerRequestOptions());
+        propertiesReplace.flatMap(containerResponse -> {
+            logger.info(
+                "setupContainer(): Container {}} in {} has been updated with it's new properties.",
+                container.getId(),
+                database.getId());
+            return Mono.empty();
+        }).onErrorResume((exception) -> {
+            logger.error(
+                "setupContainer(): Unable to update properties for container {} in database {}. e: {}",
+                container.getId(),
+                database.getId(),
+                exception.getLocalizedMessage(),
+                exception);
+            return Mono.empty();
+        }).block();
+
+    }
+
+    private void largeBulkUpsertItemsWithBulkWriterAbstraction(Iterable<Family> families) {
+        List<CosmosItemOperation> cosmosItemOperations = new ArrayList<>();
+        for (Family family : families) {
+            cosmosItemOperations.add(CosmosBulkOperations.getUpsertItemOperation(family, new PartitionKey(family.getLastName())));
+        }
+        BulkWriter bulkWriter = new BulkWriter(container);
+        for (CosmosItemOperation operation : cosmosItemOperations) {
+            bulkWriter.scheduleWrites(operation);
+        }
+        bulkWriter.execute().subscribe();
+        //get count of items in container
+        try {
+            logger.info("Waiting for bulk operations to complete...");
+            Thread.sleep(20000); // Wait for the bulk operations to complete
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        logger.info("Number of items to create was: " + noOfItemsToCreate);
+        logger.info("Total items created after bulk load: " + container.readAllItems(new PartitionKey("Family0"), Family.class).count().block());
+    }
+    
+
+    private void shutdown() {
+        try {
+            // To allow for the sequence to complete after subscribe() calls
+            Thread.sleep(5000);
+            //Clean shutdown
+            logger.info("Deleting Cosmos DB resources");
+            logger.info("-Deleting container...");
+            if (container != null) container.delete().subscribe();
+            logger.info("-Deleting database...");
+            if (database != null) database.delete().subscribe();
+            logger.info("-Closing the client...");
+        } catch (InterruptedException err) {
+            err.printStackTrace();
+        } catch (Exception err) {
+            logger.error("Deleting Cosmos DB resources failed, will still attempt to close the client. See stack " + "trace below.");
+            err.printStackTrace();
+        }
+        client.close();
+        logger.info("Done.");
+    }
+
+
+}

--- a/src/main/java/com/azure/cosmos/examples/bulk/sync/BulkWriter.java
+++ b/src/main/java/com/azure/cosmos/examples/bulk/sync/BulkWriter.java
@@ -1,10 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
 
-/*
-  The BulkWriter class is an attempt to provide guidance for creating
-  a higher level abstraction over the existing low level Java Bulk API
- */
 package com.azure.cosmos.examples.bulk.sync;
 
 import com.azure.cosmos.CosmosContainer;
@@ -16,134 +10,159 @@ import com.azure.cosmos.models.CosmosBulkOperationResponse;
 import com.azure.cosmos.models.CosmosItemOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Sinks;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Semaphore;
 
 public class BulkWriter {
     private static final Logger logger = LoggerFactory.getLogger(BulkWriter.class);
 
-    private final Sinks.Many<CosmosItemOperation> bulkInputEmitter = Sinks.many().unicast().onBackpressureBuffer();
-    private final int cpuCount = Runtime.getRuntime().availableProcessors();
-
-    //Max items to be buffered to avoid out of memory error
-    private final Semaphore semaphore = new Semaphore(1024 * 167 / cpuCount);
-
-    private final Sinks.EmitFailureHandler emitFailureHandler =
-            (signalType, emitResult) -> {
-                if (emitResult.equals(Sinks.EmitResult.FAIL_NON_SERIALIZED)) {
-                    logger.debug("emitFailureHandler - Signal: [{}], Result: [{}]", signalType, emitResult);
-                    return true;
-                } else {
-                    logger.error("emitFailureHandler - Signal: [{}], Result: [{}]", signalType, emitResult);
-                    return false;
-                }
-            };
-
     private final CosmosContainer cosmosContainer;
+    private final int cpuCount = Runtime.getRuntime().availableProcessors();
+    private final Semaphore semaphore = new Semaphore(1024 * 167 / cpuCount);
+    private final List<CosmosItemOperation> bufferedOperations = new ArrayList<>();
+    private final int maxRetries = 5;
 
     public BulkWriter(CosmosContainer cosmosContainer) {
         this.cosmosContainer = cosmosContainer;
     }
 
     public void scheduleWrites(CosmosItemOperation cosmosItemOperation) {
-        while(!semaphore.tryAcquire()) {
+        while (!semaphore.tryAcquire()) {
             logger.info("Unable to acquire permit");
         }
         logger.info("Acquired permit");
-        scheduleInternalWrites(cosmosItemOperation);
-    }
-
-    private void scheduleInternalWrites(CosmosItemOperation cosmosItemOperation) {
-        bulkInputEmitter.emitNext(cosmosItemOperation, emitFailureHandler);
+        bufferedOperations.add(cosmosItemOperation);
     }
 
     public Iterable<CosmosBulkOperationResponse<Object>> execute() {
-        return this.execute(null);
+        return execute(null);
     }
 
     public Iterable<CosmosBulkOperationResponse<Object>> execute(CosmosBulkExecutionOptions bulkOptions) {
         if (bulkOptions == null) {
             bulkOptions = new CosmosBulkExecutionOptions();
         }
-        bulkInputEmitter.tryEmitComplete();
-        Iterable<CosmosBulkOperationResponse<Object>> bulkOperationResponse = cosmosContainer
-                .executeBulkOperations(
-                        bulkInputEmitter.asFlux().toIterable(),
-                        bulkOptions);
-        for (CosmosBulkOperationResponse<Object> response : bulkOperationResponse) {
-            processBulkOperationResponse(
-                response.getResponse(),
-                response.getOperation(),
-                response.getException());
+
+        List<CosmosItemOperation> currentBatch = new ArrayList<>(bufferedOperations);
+        bufferedOperations.clear();
+        List<CosmosBulkOperationResponse<Object>> finalResponses = new ArrayList<>();
+        int attempt = 0;
+
+        while (!currentBatch.isEmpty() && attempt <= maxRetries) {
+            logger.info("Executing bulk attempt {} with {} items", attempt + 1, currentBatch.size());
+
+            Iterable<CosmosBulkOperationResponse<Object>> responses =
+                    cosmosContainer.executeBulkOperations(currentBatch, bulkOptions);
+
+            List<CosmosItemOperation> toRetry = new ArrayList<>();
+
+            for (CosmosBulkOperationResponse<Object> response : responses) {
+                processBulkOperationResponse(
+                        response.getResponse(),
+                        response.getOperation(),
+                        response.getException(),
+                        toRetry
+                );
+                finalResponses.add(response);
+            }
+
+            currentBatch = toRetry;
+            attempt++;
         }
+
+        if (!currentBatch.isEmpty()) {
+            logger.error("BulkWriter: {} items failed after {} retries", currentBatch.size(), maxRetries);
+        }
+
         semaphore.release();
-        return bulkOperationResponse;
+        return finalResponses;
     }
 
-
-
-
     private void processBulkOperationResponse(
-        CosmosBulkItemResponse itemResponse,
-        CosmosItemOperation itemOperation,
-        Exception exception) {
+            CosmosBulkItemResponse itemResponse,
+            CosmosItemOperation itemOperation,
+            Exception exception,
+            List<CosmosItemOperation> retryList) {
 
         if (exception != null) {
-            handleException(itemOperation, exception);
+            handleException(itemOperation, exception, retryList);
         } else {
-            processResponseCode(itemResponse, itemOperation);
+            processResponseCode(itemResponse, itemOperation, retryList);
         }
     }
 
     private void processResponseCode(
-        CosmosBulkItemResponse itemResponse,
-        CosmosItemOperation itemOperation) {
+            CosmosBulkItemResponse itemResponse,
+            CosmosItemOperation itemOperation,
+            List<CosmosItemOperation> retryList) {
 
         if (itemResponse.isSuccessStatusCode()) {
             logger.info(
-                "The operation for Item ID: [{}]  Item PartitionKey Value: [{}] completed successfully " +
-                    "with a response status code: [{}]",
-                itemOperation.getId(),
-                itemOperation.getPartitionKeyValue(),
-                itemResponse.getStatusCode());
+                    "Item ID [{}] with PartitionKey [{}] succeeded with status [{}]",
+                    itemOperation.getId(),
+                    itemOperation.getPartitionKeyValue(),
+                    itemResponse.getStatusCode());
         } else if (shouldRetry(itemResponse.getStatusCode())) {
             logger.info(
-                "The operation for Item ID: [{}]  Item PartitionKey Value: [{}] will be retried",
-                itemOperation.getId(),
-                itemOperation.getPartitionKeyValue());
-            //re-scheduling
-            scheduleWrites(itemOperation);
+                    "Item ID [{}] with PartitionKey [{}] will be retried (status [{}])",
+                    itemOperation.getId(),
+                    itemOperation.getPartitionKeyValue(),
+                    itemResponse.getStatusCode());
+            if (itemResponse.getRetryAfterDuration() != null) {
+                logger.info(
+                        "Item ID [{}] with PartitionKey [{}] will be retried after [{}] milliseconds",
+                        itemOperation.getId(),
+                        itemOperation.getPartitionKeyValue(),
+                        itemResponse.getRetryAfterDuration().toMillis());
+                try {
+                    Thread.sleep(itemResponse.getRetryAfterDuration().toMillis());
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            retryList.add(itemOperation);
         } else {
             logger.info(
-                "The operation for Item ID: [{}]  Item PartitionKey Value: [{}] did not complete successfully " +
-                    "with a response status code: [{}]",
-                itemOperation.getId(),
-                itemOperation.getPartitionKeyValue(),
-                itemResponse.getStatusCode());
+                    "Item ID [{}] with PartitionKey [{}] failed with non-retryable status [{}]",
+                    itemOperation.getId(),
+                    itemOperation.getPartitionKeyValue(),
+                    itemResponse.getStatusCode());
         }
     }
 
-    private void handleException(CosmosItemOperation itemOperation, Exception exception) {
+    private void handleException(
+            CosmosItemOperation itemOperation,
+            Exception exception,
+            List<CosmosItemOperation> retryList) {
+
         if (!(exception instanceof CosmosException)) {
             logger.info(
-                "The operation for Item ID: [{}]  Item PartitionKey Value: [{}] encountered an unexpected failure",
-                itemOperation.getId(),
-                itemOperation.getPartitionKeyValue());
-        } else {
-            if (shouldRetry(((CosmosException) exception).getStatusCode())) {
-                logger.info(
-                    "The operation for Item ID: [{}]  Item PartitionKey Value: [{}] will be retried",
+                    "Item ID [{}] with PartitionKey [{}] encountered unexpected failure",
                     itemOperation.getId(),
                     itemOperation.getPartitionKeyValue());
-
-                //re-scheduling
-                scheduleWrites(itemOperation);
+        } else {
+            int statusCode = ((CosmosException) exception).getStatusCode();
+            if (shouldRetry(statusCode)) {
+                logger.info(
+                        "Item ID [{}] with PartitionKey [{}] will be retried due to exception status [{}]",
+                        itemOperation.getId(),
+                        itemOperation.getPartitionKeyValue(),
+                        statusCode);
+                retryList.add(itemOperation);
+            } else {
+                logger.error(
+                        "Item ID [{}] with PartitionKey [{}] failed with non-retryable exception: {}",
+                        itemOperation.getId(),
+                        itemOperation.getPartitionKeyValue(),
+                        exception.getMessage());
             }
         }
     }
 
     private boolean shouldRetry(int statusCode) {
         return statusCode == HttpConstants.StatusCodes.REQUEST_TIMEOUT ||
-            statusCode == HttpConstants.StatusCodes.TOO_MANY_REQUESTS;
+                statusCode == HttpConstants.StatusCodes.TOO_MANY_REQUESTS;
     }
 }

--- a/src/main/java/com/azure/cosmos/examples/bulk/sync/BulkWriter.java
+++ b/src/main/java/com/azure/cosmos/examples/bulk/sync/BulkWriter.java
@@ -19,6 +19,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Semaphore;
 
 public class BulkWriter {
@@ -27,7 +29,7 @@ public class BulkWriter {
     private final CosmosContainer cosmosContainer;
     private final int cpuCount = Runtime.getRuntime().availableProcessors();
     private final Semaphore semaphore = new Semaphore(1024 * 167 / cpuCount);
-    private final List<CosmosItemOperation> bufferedOperations = new ArrayList<>();
+    private final Queue<CosmosItemOperation> bufferedOperations = new ConcurrentLinkedQueue<>();
     private final int maxRetries = 5;
 
     public BulkWriter(CosmosContainer cosmosContainer) {
@@ -168,7 +170,11 @@ public class BulkWriter {
     }
 
     private boolean shouldRetry(int statusCode) {
-        return statusCode == HttpConstants.StatusCodes.REQUEST_TIMEOUT ||
-                statusCode == HttpConstants.StatusCodes.TOO_MANY_REQUESTS;
+        return statusCode == 408 ||
+                statusCode == 429 ||
+                statusCode == 503 ||
+                statusCode == 500 ||
+                statusCode == 449 ||
+                statusCode == 410;
     }
 }

--- a/src/main/java/com/azure/cosmos/examples/bulk/sync/BulkWriter.java
+++ b/src/main/java/com/azure/cosmos/examples/bulk/sync/BulkWriter.java
@@ -1,4 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
+/*
+  The BulkWriter class is an attempt to provide guidance for creating
+  a higher level abstraction over the existing low level Java Bulk API
+ */
 package com.azure.cosmos.examples.bulk.sync;
 
 import com.azure.cosmos.CosmosContainer;

--- a/src/main/java/com/azure/cosmos/examples/bulk/sync/SampleBulkQuickStart.java
+++ b/src/main/java/com/azure/cosmos/examples/bulk/sync/SampleBulkQuickStart.java
@@ -26,6 +26,7 @@ import com.azure.cosmos.models.CosmosBulkExecutionOptions;
 import com.azure.cosmos.models.CosmosBulkItemResponse;
 import com.azure.cosmos.models.CosmosBulkOperations;
 import com.azure.cosmos.models.CosmosItemRequestOptions;
+import com.azure.identity.DefaultAzureCredentialBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,14 +79,15 @@ public class SampleBulkQuickStart {
         //  <CreateAsyncClient>
         client = new CosmosClientBuilder()
                 .endpoint(AccountSettings.HOST)
-                .key(AccountSettings.MASTER_KEY)
+                .credential(new DefaultAzureCredentialBuilder().build())
                 .preferredRegions(preferredRegions)
                 .contentResponseOnWriteEnabled(true)
                 .consistencyLevel(ConsistencyLevel.SESSION).buildClient();
 
         //  </CreateAsyncClient>
 
-        createDatabaseIfNotExists();
+        // Note: database must already exist (cannot be created via RBAC).
+        database = client.getDatabase(databaseName);
         createContainerIfNotExists();
 
         //  <CreateDocs>
@@ -153,17 +155,6 @@ public class SampleBulkQuickStart {
         bulkUpsertItemsWithBulkWriterAbstractionAndLocalThroughPutControl();
         logger.info("Bulk upserts with BulkWriter Abstraction and Global Throughput Control");
         bulkCreateItemsWithBulkWriterAbstractionAndGlobalThroughputControl();
-    }
-
-    private void createDatabaseIfNotExists() {
-        logger.info("Create database " + databaseName + " if not exists.");
-
-        //  Create database if not exists
-        //  <CreateDatabaseIfNotExists>
-        CosmosDatabaseResponse databaseIfNotExists = client.createDatabaseIfNotExists(databaseName);
-        database = client.getDatabase(databaseIfNotExists.getProperties().getId());
-        logger.info("Checking database " + database.getId() + " completed!\n");
-        //  </CreateDatabaseIfNotExists>
     }
 
     private void createContainerIfNotExists() {
@@ -376,8 +367,6 @@ public class SampleBulkQuickStart {
             logger.info("Deleting Cosmos DB resources");
             logger.info("-Deleting container...");
             if (container != null) container.delete();
-            logger.info("-Deleting database...");
-            if (database != null) database.delete();
             logger.info("-Closing the client...");
         } catch (InterruptedException err) {
             err.printStackTrace();


### PR DESCRIPTION
Changes and additions to bulk samples:

- Add new samples `SampleBulkHandleRetries` for sync and async that simulate 429 retry limit being exhausted in SDK and handled during bulk execution.
- Minor change to **async** and **sync** BulkWriter to use retryAfter property returned from server.
- Major changes to **sync** BulkWriter: `Sinks.Many` is designed for reactive non-blocking streams, but Cosmos sync API is blocking and expects a fully buffered `Iterable`. Using `Sinks.Many` causes hangs or dropped retries because it requires completion and can't accept new items afterward, making it not suitable for continuous retries in bulk execution using sync container. Instead using simple in-memory List to buffer operations - this allows full control over retries in sync model.
- Added `DefaultAzureCredential` to all samples and remove create database calls.